### PR TITLE
openra: Add the OpenRA game and repository

### DIFF
--- a/FOSSawesomeGames.json
+++ b/FOSSawesomeGames.json
@@ -53,6 +53,12 @@
             "type":"Game",
             "license":"GPLv1",
             "link":"http://www.codersnotes.com/files/gamesrc/rottsource.zip"
-        }
+        },
+	{
+	    "title":"OpenRA",
+	    "type":"Game",
+	    "license":"GPLv3",
+	    "link":"https://github.com/OpenRA/OpenRA"
+	}
     ]
 }


### PR DESCRIPTION
OpenRA is an open source implementation of Command & Conquer, under the GPLv3
license.
